### PR TITLE
update kotlin version to 1.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 }
 
 buildscript {
-    ext.kotlin_version = '1.0.0-beta-4589'
+    ext.kotlin_version = '1.0.2'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
the jar produced by building with the old kotlin beta cannot be used with the current kotlin compiler
